### PR TITLE
fix: add resolutions for tar>=7.5.8 and minimatch>=3.1.3 to address C…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,82 +1,84 @@
 {
-  "name": "cyberid",
-  "version": "1.0.0",
-  "main": "index.js",
-  "repository": "git@github.com:cyberconnecthq/cyberid.git",
-  "author": "peng.deng@cyberconnect.me",
-  "license": "GPL-3.0-or-later",
-  "scripts": {
-    "lint:gh-check": "prettier --check **.{sol,js,md,html}",
-    "lint:check": "prettier --check **.{sol,js,md,html} && solhint --config ./config/.solhint.json --ignore-path ./config/.solhintignore -f table 'src/**/*.sol'",
-    "lint:fix": "prettier --write **.{sol,js,md}",
-    "prepare": "husky install",
-    "build": "forge build --force",
-    "gen_abi": "ts-node misc/gen_abi.ts",
-    "deploy_realmid:mumbai": "source .env.mumbai && forge script script/DeployRealmId.s.sol:DeployRealmId --verify --rpc-url $RPC_URL --legacy --private-key $PRIVATE_KEY --broadcast -vvv",
-    "deploy_cyberid:op_goerli": "source .env.op_goerli && forge script script/DeployCyberId.s.sol:DeployCyberId --verify --rpc-url $RPC_URL --private-key $PRIVATE_KEY  --etherscan-api-key $API_KEY --broadcast -vvv",
-    "deploy_cyberid:op_sepolia": "source .env.op_sepolia.owner && forge script script/DeployCyberId.s.sol:DeployCyberId --verify --rpc-url $RPC_URL --private-key $PRIVATE_KEY  --etherscan-api-key  $API_KEY --broadcast  --slow -vvv",
-    "deploy_cyberid:op": "source .env.op && forge script script/DeployCyberId.s.sol:DeployCyberId --verify --rpc-url $RPC_URL --private-key $PRIVATE_KEY  --etherscan-api-key $API_KEY  --broadcast -vvv",
-    "deploy_cyberid:cyber_testnet": "source .env.cyber_testnet.owner && forge script script/DeployCyberId.s.sol:DeployCyberId --verify --verifier blockscout --verifier-url https://api.socialscan.io/cyber-testnet/v1/explorer/command_api/contract --chain-id 111557560 --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
-    "deploy_mock_oracle:cyber_testnet": "source .env.cyber_testnet.owner && forge script script/DeployCyberId.s.sol:DeployMockOracle --verify --verifier blockscout --verifier-url https://api.socialscan.io/cyber-testnet/v1/explorer/command_api/contract --chain-id 111557560 --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
-    "deploy_cyberid:cyber": "source .env.cyber.owner && forge script script/DeployCyberId.s.sol:DeployCyberId --verify --verifier blockscout --verifier-url https://api.socialscan.io/cyber/v1/explorer/command_api/contract --chain-id 7560 --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
-    "deploy_cyberid_stablemw:op": "source .env.op.owner && forge script script/DeployCyberIdStableMw.s.sol:DeployCyberIdStableMw --verify --rpc-url $RPC_URL --private-key $PRIVATE_KEY  --etherscan-api-key $API_KEY --broadcast -vvv",
-    "set_cyberid_mw:op_sepolia": "source .env.op_sepolia.owner && forge script script/SetCyberIdMw.s.sol:SetCyberIdMw --rpc-url $RPC_URL --private-key $PRIVATE_KEY --verify   --etherscan-api-key $API_KEY  --broadcast --slow -vvv",
-    "set_cyberid_mw:op": "source .env.op.owner && forge script script/SetCyberIdMw.s.sol:SetCyberIdMw --rpc-url $RPC_URL --private-key $PRIVATE_KEY  --broadcast -vvv",
-    "set_cyberid_mw:cyber_testnet": "source .env.cyber_testnet.owner && forge script script/SetCyberIdMw.s.sol:SetCyberIdMw --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast --slow --verify --verifier blockscout --verifier-url https://api.socialscan.io/cyber-testnet/v1/explorer/command_api/contract --chain-id 111557560 -vvv",
-    "set_cyberid_mw:cyber": "source .env.cyber.owner && forge script script/SetCyberIdMw.s.sol:SetCyberIdMw --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast --slow --verify --verifier blockscout --verifier-url https://api.socialscan.io/cyber/v1/explorer/command_api/contract --chain-id 7560 -vvv",
-    "set_cyberid_init_state:op": "source .env.op.owner && forge script script/SetCyberIDInitState.s.sol:SetCyberIDInitState --rpc-url $RPC_URL --private-key $PRIVATE_KEY  --broadcast -vvv",
-    "set_cyberid_init_state:op_goerli": "source .env.op_goerli.owner && forge script script/SetCyberIDInitState.s.sol:SetCyberIDInitState --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
-    "temp_script:op_goerli": "source .env.op_goerli.owner && forge script script/Tmp.s.sol:TempScript --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
-    "temp_script:op": "source .env.op.owner && forge script script/Tmp.s.sol:TempScript --rpc-url $RPC_URL --private-key $PRIVATE_KEY  --broadcast -vvv",
-    "temp_script:cyber_testnet": "source .env.cyber_testnet.owner && forge script script/Tmp.s.sol:TempScript --rpc-url $RPC_URL --private-key $PRIVATE_KEY  --broadcast -vvv",
-    "temp_script:cyber": "source .env.cyber.owner && forge script script/Tmp.s.sol:TempScript --rpc-url $RPC_URL --private-key $PRIVATE_KEY  --broadcast -vvv",
-    "verify_cyberid:op_goerli": "source .env.op_goerli && ETHERSCAN_API_KEY=$API_KEY forge verify-contract --chain-id 420 --compiler-version v0.8.14+commit.80d49f37  0x011db522044b03f68311486e63785e90980d0cc3 src/core/CyberId.sol:CyberId  --watch",
-    "verify_cyberid:op": "source .env.op && ETHERSCAN_API_KEY=$API_KEY forge verify-contract --chain-id 10 --compiler-version v0.8.14+commit.80d49f37  0x71455a99fe9ed6e2501297b1331d135225a41b81 src/core/CyberId.sol:CyberId  --watch",
-    "verify_permissioned_stablefeemw:op": "source .env.op && ETHERSCAN_API_KEY=$API_KEY forge verify-contract --chain-id 10 --compiler-version v0.8.14+commit.80d49f37 --constructor-args 00000000000000000000000013e3ee699d1909e989722e753853ae30b17e08c5000000000000000000000000cd97405fb58e94954e825e46db192b916a45d412000000000000000000000000714638def68cf32a641b0735e489733b3187f431 0x889c6bb8d1dfbc0210007db15404afb4c4ba913e src/middlewares/cyberid/PermissionedStableFeeMiddleware.sol:PermissionedStableFeeMiddleware  --watch",
-    "verify_permissionmw:mumbai": "source .env.mumbai && ETHERSCAN_API_KEY=$API_KEY forge verify-contract --chain-id 80001 --compiler-version v0.8.14+commit.80d49f37 --constructor-args 0000000000000000000000001ef669e1a6d2aeef4741761488d473ece9810b05 0x31f627dc0030334e62f8ca53c3cf730bb8417081 src/middlewares/realmid/PermissionMw.sol:PermissionMw  --watch",
-    "verify_realmid:mumbai": "source .env.mumbai && ETHERSCAN_API_KEY=$API_KEY forge verify-contract --chain-id 80001 --compiler-version v0.8.14+commit.80d49f37 0xf7cc42298b05931d93cd81d9513f8ed4ebe6bde1 src/core/RealmId.sol:RealmId  --watch"
-  },
-  "dependencies": {
-    "elliptic": "npm:@soatok/elliptic-to-noble@^9999.0.0"
-  },
-  "devDependencies": {
-    "husky": "^8.0.1",
-    "lint-staged": "^13.0.1",
-    "prettier": "^2.7.1",
-    "prettier-plugin-solidity": "^1.0.0-beta.19",
-    "solhint": "^3.3.7",
-    "solhint-plugin-prettier": "^0.0.5",
-    "solidity-coverage": "^0.7.21",
-    "ts-node": "^10.8.2",
-    "typechain": "^8.1.0",
-    "typescript": "^4.7.4"
-  },
-  "lint-staged": {
-    "*.{sol,js,md,html}": "prettier --write"
-  },
-  "prettier": {
-    "overrides": [
-      {
-        "files": "*.sol",
-        "options": {
-          "tabWidth": 4,
-          "printWidth": 80,
-          "bracketSpacing": true
-        }
-      }
-    ]
-  },
-  "resolutions": {
-    "elliptic": "npm:@soatok/elliptic-to-noble@^9999.0.0",
-    "pbkdf2": ">=3.1.3",
-    "form-data": "^2.5.4",
-    "cipher-base": ">=1.0.5",
-    "sha.js": ">=2.4.12",
-    "ws": "^7.5.10",
-    "body-parser": "^1.20.3",
-    "braces": "^3.0.3",
-    "secp256k1": "^4.0.4",
-    "base-x": "^3.0.11",
-    "qs": ">=6.14.1"
-  }
+    "name": "cyberid",
+    "version": "1.0.0",
+    "main": "index.js",
+    "repository": "git@github.com:cyberconnecthq/cyberid.git",
+    "author": "peng.deng@cyberconnect.me",
+    "license": "GPL-3.0-or-later",
+    "scripts": {
+          "lint:gh-check": "prettier --check **.{sol,js,md,html}",
+          "lint:check": "prettier --check **.{sol,js,md,html} && solhint --config ./config/.solhint.json --ignore-path ./config/.solhintignore -f table 'src/**/*.sol'",
+          "lint:fix": "prettier --write **.{sol,js,md}",
+          "prepare": "husky install",
+          "build": "forge build --force",
+          "gen_abi": "ts-node misc/gen_abi.ts",
+          "deploy_realmid:mumbai": "source .env.mumbai && forge script script/DeployRealmId.s.sol:DeployRealmId --verify --rpc-url $RPC_URL --legacy --private-key $PRIVATE_KEY --broadcast -vvv",
+          "deploy_cyberid:op_goerli": "source .env.op_goerli && forge script script/DeployCyberId.s.sol:DeployCyberId --verify --rpc-url $RPC_URL --private-key $PRIVATE_KEY --etherscan-api-key $API_KEY --broadcast -vvv",
+          "deploy_cyberid:op_sepolia": "source .env.op_sepolia.owner && forge script script/DeployCyberId.s.sol:DeployCyberId --verify --rpc-url $RPC_URL --private-key $PRIVATE_KEY --etherscan-api-key $API_KEY --broadcast --slow -vvv",
+          "deploy_cyberid:op": "source .env.op && forge script script/DeployCyberId.s.sol:DeployCyberId --verify --rpc-url $RPC_URL --private-key $PRIVATE_KEY --etherscan-api-key $API_KEY --broadcast -vvv",
+          "deploy_cyberid:cyber_testnet": "source .env.cyber_testnet.owner && forge script script/DeployCyberId.s.sol:DeployCyberId --verify --verifier blockscout --verifier-url https://api.socialscan.io/cyber-testnet/v1/explorer/command_api/contract --chain-id 111557560 --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
+          "deploy_mock_oracle:cyber_testnet": "source .env.cyber_testnet.owner && forge script script/DeployCyberId.s.sol:DeployMockOracle --verify --verifier blockscout --verifier-url https://api.socialscan.io/cyber-testnet/v1/explorer/command_api/contract --chain-id 111557560 --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
+          "deploy_cyberid:cyber": "source .env.cyber.owner && forge script script/DeployCyberId.s.sol:DeployCyberId --verify --verifier blockscout --verifier-url https://api.socialscan.io/cyber/v1/explorer/command_api/contract --chain-id 7560 --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
+          "deploy_cyberid_stablemw:op": "source .env.op.owner && forge script script/DeployCyberIdStableMw.s.sol:DeployCyberIdStableMw --verify --rpc-url $RPC_URL --private-key $PRIVATE_KEY --etherscan-api-key $API_KEY --broadcast -vvv",
+          "set_cyberid_mw:op_sepolia": "source .env.op_sepolia.owner && forge script script/SetCyberIdMw.s.sol:SetCyberIdMw --rpc-url $RPC_URL --private-key $PRIVATE_KEY --verify --etherscan-api-key $API_KEY --broadcast --slow -vvv",
+          "set_cyberid_mw:op": "source .env.op.owner && forge script script/SetCyberIdMw.s.sol:SetCyberIdMw --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
+          "set_cyberid_mw:cyber_testnet": "source .env.cyber_testnet.owner && forge script script/SetCyberIdMw.s.sol:SetCyberIdMw --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast --slow --verify --verifier blockscout --verifier-url https://api.socialscan.io/cyber-testnet/v1/explorer/command_api/contract --chain-id 111557560 -vvv",
+          "set_cyberid_mw:cyber": "source .env.cyber.owner && forge script script/SetCyberIdMw.s.sol:SetCyberIdMw --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast --slow --verify --verifier blockscout --verifier-url https://api.socialscan.io/cyber/v1/explorer/command_api/contract --chain-id 7560 -vvv",
+          "set_cyberid_init_state:op": "source .env.op.owner && forge script script/SetCyberIDInitState.s.sol:SetCyberIDInitState --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
+          "set_cyberid_init_state:op_goerli": "source .env.op_goerli.owner && forge script script/SetCyberIDInitState.s.sol:SetCyberIDInitState --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
+          "temp_script:op_goerli": "source .env.op_goerli.owner && forge script script/Tmp.s.sol:TempScript --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
+          "temp_script:op": "source .env.op.owner && forge script script/Tmp.s.sol:TempScript --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
+          "temp_script:cyber_testnet": "source .env.cyber_testnet.owner && forge script script/Tmp.s.sol:TempScript --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
+          "temp_script:cyber": "source .env.cyber.owner && forge script script/Tmp.s.sol:TempScript --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast -vvv",
+          "verify_cyberid:op_goerli": "source .env.op_goerli && ETHERSCAN_API_KEY=$API_KEY forge verify-contract --chain-id 420 --compiler-version v0.8.14+commit.80d49f37 0x011db522044b03f68311486e63785e90980d0cc3 src/core/CyberId.sol:CyberId --watch",
+          "verify_cyberid:op": "source .env.op && ETHERSCAN_API_KEY=$API_KEY forge verify-contract --chain-id 10 --compiler-version v0.8.14+commit.80d49f37 0x71455a99fe9ed6e2501297b1331d135225a41b81 src/core/CyberId.sol:CyberId --watch",
+          "verify_permissioned_stablefeemw:op": "source .env.op && ETHERSCAN_API_KEY=$API_KEY forge verify-contract --chain-id 10 --compiler-version v0.8.14+commit.80d49f37 --constructor-args 00000000000000000000000013e3ee699d1909e989722e753853ae30b17e08c5000000000000000000000000cd97405fb58e94954e825e46db192b916a45d412000000000000000000000000714638def68cf32a641b0735e489733b3187f431 0x889c6bb8d1dfbc0210007db15404afb4c4ba913e src/middlewares/cyberid/PermissionedStableFeeMiddleware.sol:PermissionedStableFeeMiddleware --watch",
+          "verify_permissionmw:mumbai": "source .env.mumbai && ETHERSCAN_API_KEY=$API_KEY forge verify-contract --chain-id 80001 --compiler-version v0.8.14+commit.80d49f37 --constructor-args 0000000000000000000000001ef669e1a6d2aeef4741761488d473ece9810b05 0x31f627dc0030334e62f8ca53c3cf730bb8417081 src/middlewares/realmid/PermissionMw.sol:PermissionMw --watch",
+          "verify_realmid:mumbai": "source .env.mumbai && ETHERSCAN_API_KEY=$API_KEY forge verify-contract --chain-id 80001 --compiler-version v0.8.14+commit.80d49f37 0xf7cc42298b05931d93cd81d9513f8ed4ebe6bde1 src/core/RealmId.sol:RealmId --watch"
+    },
+    "dependencies": {
+          "elliptic": "npm:@soatok/elliptic-to-noble@^9999.0.0"
+    },
+    "devDependencies": {
+          "husky": "^8.0.1",
+          "lint-staged": "^13.0.1",
+          "prettier": "^2.7.1",
+          "prettier-plugin-solidity": "^1.0.0-beta.19",
+          "solhint": "^3.3.7",
+          "solhint-plugin-prettier": "^0.0.5",
+          "solidity-coverage": "^0.7.21",
+          "ts-node": "^10.8.2",
+          "typechain": "^8.1.0",
+          "typescript": "^4.7.4"
+    },
+    "lint-staged": {
+          "*.{sol,js,md,html}": "prettier --write"
+    },
+    "prettier": {
+          "overrides": [
+                  {
+                            "files": "*.sol",
+                            "options": {
+                                        "tabWidth": 4,
+                                        "printWidth": 80,
+                                        "bracketSpacing": true
+                            }
+                  }
+          ]
+    },
+    "resolutions": {
+          "elliptic": "npm:@soatok/elliptic-to-noble@^9999.0.0",
+          "pbkdf2": ">=3.1.3",
+          "form-data": "^2.5.4",
+          "cipher-base": ">=1.0.5",
+          "sha.js": ">=2.4.12",
+          "ws": "^7.5.10",
+          "body-parser": "^1.20.3",
+          "braces": "^3.0.3",
+          "secp256k1": "^4.0.4",
+          "base-x": "^3.0.11",
+          "qs": ">=6.14.1",
+          "tar": ">=7.5.8",
+          "minimatch": ">=3.1.3"
+    }
 }


### PR DESCRIPTION
## Security: Fix high severity npm vulnerabilities

This PR adds `resolutions` entries in `package.json` to force safe versions of vulnerable transitive dependencies, addressing the following CVEs flagged by Vanta/GitHub Dependabot:

### Fixed vulnerabilities
- **CVE-2026-23950** – `npm-tar <= 7.5.3` → forced to `>=7.5.8`
- - **CVE-2026-26960** – `npm-tar < 7.5.8` → forced to `>=7.5.8`
- - **CVE-2026-26996** – `npm-minimatch < 3.1.3` → forced to `>=3.1.3`
### Changes
Added to `resolutions` in `package.json`:
```json
"tar": ">=7.5.8",
"minimatch": ">=3.1.3"
```

These resolutions ensure that all transitive dependencies resolve to safe versions of `tar` and `minimatch`.